### PR TITLE
Fix starboard threshold to count individual emoji, not total reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All commands require **Manage Channels** and **Manage Messages** permissions.
 
 | Command | Description |
 |---------|-------------|
-| `\|threshold <number>` | Change the minimum total reactions needed before a message is pinned. Raise it to make the starboard more exclusive; lower it to be more permissive. |
+| `\|threshold <number>` | Change the minimum number of reactions of a *single* emoji needed before a message is pinned. Reactions from different emoji are not added together — one emoji has to reach the number on its own. Raise it to make the starboard more exclusive; lower it to be more permissive. |
 
 ### Channel exceptions
 
@@ -133,10 +133,10 @@ Every time any user adds a reaction to any message, the bot evaluates it:
 1. **Channel filter** — if the message's channel is on the ignore list, stop.
 2. **Reaction filter** — if the specific emoji added is on the ignore list, stop.
 3. **Config check** — if this server hasn't been set up yet, stop.
-4. **Count reactions** — sum all reactions across all emoji types, excluding ignored emoji.
+4. **Count reactions** — count each emoji separately (excluding ignored emoji) and take the highest single-emoji count. Counts are never summed across different emoji.
 5. **Already pinned?**
    - Yes → update the existing starboard embed with the new count.
-   - No, and count ≥ threshold → post a new embed to the starboard channel and record the pin.
+   - No, and the highest single-emoji count ≥ threshold → post a new embed to the starboard channel and record the pin.
 
 Reaction removals are not currently handled. A message that reaches the threshold stays pinned even if reactions are later removed.
 

--- a/bot/starboard.py
+++ b/bot/starboard.py
@@ -34,7 +34,8 @@ def _pick_winning_emoji(
     Return (winning_emoji_display, winning_count).
 
     Rules:
-    - The emoji with the highest reaction count wins.
+    - The emoji with the highest reaction count wins. Counts are never summed
+      across emoji — each emoji is judged on its own count.
     - On a tie, the current stored winner (i.e. the one that broke the threshold
       first) is preferred — it keeps its position.
     - Ignored emoji are skipped entirely.
@@ -59,15 +60,8 @@ def _pick_winning_emoji(
     return (best_display or "⭐", best_count)
 
 
-def _count_reactions(message: discord.Message, ignored: set[str]) -> int:
-    return sum(
-        r.count for r in message.reactions if _emoji_str(r.emoji) not in ignored
-    )
-
-
 def _build_embed(
     message: discord.Message,
-    reaction_count: int,
     winning_emoji: str,
     winning_count: int,
 ) -> discord.Embed:
@@ -131,7 +125,6 @@ async def handle_reaction(
     except discord.NotFound:
         return
 
-    reaction_count = _count_reactions(message, ignored_reactions)
     threshold = config["threshold"]
     starboard_channel_id = config["starboard_channel_id"]
 
@@ -153,22 +146,23 @@ async def handle_reaction(
         try:
             sb_msg = await starboard_channel.fetch_message(pin["starboard_message_id"])
             await sb_msg.edit(
-                embed=_build_embed(message, reaction_count, winning_emoji, winning_count)
+                embed=_build_embed(message, winning_emoji, winning_count)
             )
         except discord.NotFound:
             pass
         return
 
-    if reaction_count >= threshold:
-        # The emoji currently being added broke (or contributed to breaking) the
-        # threshold — treat it as the initial winner, then let _pick_winning_emoji
-        # confirm whether another emoji already has a higher count.
-        trigger_display = _emoji_display(payload.emoji)
-        winning_emoji, winning_count = _pick_winning_emoji(
-            message, ignored_reactions, trigger_display
-        )
+    # A message qualifies only when a *single* emoji reaches the threshold on its
+    # own. Other reactions may be present, but their counts are not added in.
+    # The emoji being added right now is treated as the initial winner so it wins
+    # ties against emoji that reached the same count earlier.
+    trigger_display = _emoji_display(payload.emoji)
+    winning_emoji, winning_count = _pick_winning_emoji(
+        message, ignored_reactions, trigger_display
+    )
 
-        embed = _build_embed(message, reaction_count, winning_emoji, winning_count)
+    if winning_count >= threshold:
+        embed = _build_embed(message, winning_emoji, winning_count)
         sb_msg = await starboard_channel.send(embed=embed)
         await db.create_pin(
             pool,


### PR DESCRIPTION
## Summary
Changed the starboard threshold logic to require a *single* emoji to reach the threshold count, rather than summing reactions across all emoji types. This makes the starboard behavior more intuitive and prevents messages from being pinned based on a mix of different reactions.

## Key Changes
- **Removed `_count_reactions()` function** — this was summing all non-ignored reactions across all emoji types
- **Updated `_pick_winning_emoji()` logic** — now always evaluates the winning emoji (treating the currently-added emoji as the initial winner), then checks if that winning emoji's count meets the threshold
- **Simplified `_build_embed()` signature** — removed the `reaction_count` parameter since it's no longer needed
- **Updated threshold check** — moved from `reaction_count >= threshold` to `winning_count >= threshold`, ensuring only the highest single-emoji count is evaluated
- **Updated documentation** — clarified in README and code comments that the threshold applies to individual emoji counts, not summed totals

## Implementation Details
The key behavioral change is in `handle_reaction()`:
- Previously: calculated total reaction count across all emoji, then checked if it exceeded threshold
- Now: always calls `_pick_winning_emoji()` to find the emoji with the highest count, then checks if *that* count exceeds the threshold
- The currently-added emoji is treated as the initial winner to ensure it wins tie-breakers against emoji that reached the same count earlier

https://claude.ai/code/session_01CUvvj4aWngiqZfuoUMcfE3